### PR TITLE
Start search when pressing enter

### DIFF
--- a/gnome/src/search_window/imp.rs
+++ b/gnome/src/search_window/imp.rs
@@ -105,6 +105,11 @@ impl SearchWindow {
     }
 
     #[template_callback]
+    fn on_entry_activated(&self, _: &adw::EntryRow) {
+        self.start_search();
+    }
+
+    #[template_callback]
     fn on_cancel_search(&self, _: &gtk::Button) {
         self.stop_search();
     }

--- a/gnome/src/search_window/search_window.blp
+++ b/gnome/src/search_window/search_window.blp
@@ -40,6 +40,7 @@ template $ClapgrepSearchWindow: Adw.ApplicationWindow {
                 Adw.EntryRow {
                   title: _("Search Pattern");
                   text: bind template.content_search bidirectional;
+                  entry-activated => $on_entry_activated() swapped;
                 }
 
                 Adw.ActionRow {


### PR DESCRIPTION
This allows to start the search simply by pressing `Enter` while the pattern is focused. `Ctrl+Enter` still works even when the pattern is not focused.